### PR TITLE
Escape html characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ version = "0.1.0"
 dependencies = [
  "ansi_colours",
  "html",
+ "html-escape",
  "itertools",
  "rstest",
 ]
@@ -174,6 +175,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944d7db81871c611549302f3014418fedbcfbc46902f97e6a1c4f53e785903d2"
 dependencies = [
  "html-sys",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
 ]
 
 [[package]]
@@ -377,6 +387,12 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ name = "anstml"
 [dependencies]
 ansi_colours = "1.2.3"
 html = "0.6.3"
+html-escape = "0.2.13"
 itertools = "0.13.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,11 @@ impl Formatter {
         for (state, text) in chain {
             if state != AnsiState::default() {
                 let mut span = Span::builder();
-                span.text(text);
+                span.text(html_escape::encode_text(&text).into_owned());
                 span.style(state.to_style());
                 art.push(span.build());
             } else {
-                art.text(text);
+                art.text(html_escape::encode_text(&text).into_owned());
             }
         }
         art.build()


### PR DESCRIPTION
Currently, `Formatter` inserts the encoded text verbatim as HTML into the output. This is undesirable for a number of reasons.

```
$ print -P '%F{red}<img src onerror=alert`1`>' | target/debug/anstml
read 32 bytes from stdin
<pre><span style="color:red;"><img src onerror=alert`1`>
</span></pre>
```

This PR adds the `html_escape` crate to, well, escape the HTML.

```
$ printf -P '%F{red}<img src onerror=alert`1`>' | target/debug/anstml
read 32 bytes from stdin
<pre><span style="color:red;">&lt;img src onerror=alert`1`&gt;
</span></pre>
```
